### PR TITLE
chore: fix typos in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,11 +128,11 @@ jobs:
       - name: Build and Test
         run: make prepublish
         env:
-          # Hack: use FORCE_COLOR so that supports-color@5 returnes true for GitHub CI
+          # Hack: use FORCE_COLOR so that supports-color@5 returns true for GitHub CI
           # Remove once `chalk` is bumped to 4.0.
           FORCE_COLOR: true
           # Note: `false` doesn't work here, because env vars are strings and Boolean('false')
-          # is true. Use the empry string instead.
+          # is true. Use the empty string instead.
           BABEL_8_BREAKING: ${{ needs.check-release-type.outputs.is-babel-8 == 'true' || '' }}
 
       - name: Publish to npm (Babel 7)


### PR DESCRIPTION
## Summary by Sourcery

Correct typos in comments within the GitHub Actions release workflow.

Chores:
- Fix typo "returnes" to "returns" in the FORCE_COLOR comment.
- Fix typo "empry" to "empty" in the BABEL_8_BREAKING comment.